### PR TITLE
Change to main in GHA

### DIFF
--- a/.github/workflows/render-specs.yml
+++ b/.github/workflows/render-specs.yml
@@ -4,7 +4,7 @@ name: spec-up-render
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-deploy-spec:


### PR DESCRIPTION
Spec-Up by default does not use "main" -- changed.
