### PR TITLE
With .gitignore change the index is missing -- trying update

### DIFF
--- a/.github/workflows/render-specs.yml
+++ b/.github/workflows/render-specs.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
           npm install
-          node -e "require('spec-up')({ nowatch: true })"
+          npm run render
+          node -e "require('./index')({ nowatch: true })"
           rm -rf node_modules
 
       - name: Deploy

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -498,9 +498,9 @@ changed to `whois.vp`.
 ```json
 {
    "@context": "https://identity.foundation/linked-vp/contexts/v1",
-   "id": `#whois`,
+   "id": "#whois",
    "type": "LinkedVerifiablePresentation",
-   "serviceEndpoint": `https://example.com/dids/<scid>/whois.json`]
+   "serviceEndpoint": "https://example.com/dids/<scid>/whois.json"
 }
 ```
 
@@ -546,9 +546,9 @@ Thus, the implicit service for DID `did:tdw:example.com:dids:<scid>` is:
 
 ```json
 {
-   "id": `#files`,
+   "id": "#files",
    "type": "relativeRef",
-   "serviceEndpoint": `https://example.com/dids/<scid>`]
+   "serviceEndpoint": "https://example.com/dids/<scid>"
 }
 ```
 


### PR DESCRIPTION
@brianorwhatever -- the index.html on gh-pages is now missing.

Took a guess at a fix, but please look.  Does the `require` you have do a render of the page?  I thought so because of the "nowatch" parameter, but since there is no index.html, I explicitly added an `npm run render`.  Please take a look ASAP as we have shared the URL a few places.

Just looked at the output of the `npm run render` command and see that it is the same as the command following...
