### PR TITLE
Use Base58 instead of Base32 and Remove SCID shortening

### DIFF
--- a/spec/definitions.md
+++ b/spec/definitions.md
@@ -78,12 +78,12 @@ when forced to change (such as when an organization is acquired by another,
 resulting in a change of domain names) and when changing DID hosting service
 providers.
 
-[[def: base32_lower]]
+[[def: base58]]
 
-~ Applies [[spec:rfc4648]] to convert
-data to a `base32` encoding, and then lower cases the result. Data encoded as
-base32 consists of a string of characters containing only the letters A-Z and
-digits 2-7.
+~ Applies [[spec:draft-msporny-base58-03]] to convert
+data to a `base58` encoding. Data encoded as
+base58 consists of a string of characters containing only the letters A-Z, a-z and
+digits 1-9.
 
 [[def: Linked-VP, Linked Verifiable Presentation]]
 

--- a/spec/definitions.md
+++ b/spec/definitions.md
@@ -84,9 +84,7 @@ providers.
 [[def: base58btc]]
 
 ~ Applies [[spec:draft-msporny-base58-03]] to convert
-data to a `base58` encoding. Data encoded as
-base58 consists of a string of characters containing only the letters A-Z, a-z and
-digits 1-9.
+data to a `base58` encoding.
 
 [[def: Linked-VP, Linked Verifiable Presentation]]
 

--- a/spec/definitions.md
+++ b/spec/definitions.md
@@ -81,7 +81,7 @@ when forced to change (such as when an organization is acquired by another,
 resulting in a change of domain names) and when changing DID hosting service
 providers.
 
-[[def: base58]]
+[[def: base58btc]]
 
 ~ Applies [[spec:draft-msporny-base58-03]] to convert
 data to a `base58` encoding. Data encoded as

--- a/spec/definitions.md
+++ b/spec/definitions.md
@@ -42,6 +42,9 @@ make changes to a DID document.
 the data of a log entry. The generated entry hash is subsequently put into the
 log entry and *MUST* be verified by a resolver.
 
+[[def: multihash]]
+~ Per the [[spec:draft-multiformats-multihash-07]], Multihash is a specification for differentiating hashes. Multihash defines that by prefixing hashes with a hash function identifier and the hash size.
+
 [[def: Data Integrity]]
 
 ~ [W3C Data

--- a/spec/header.md
+++ b/spec/header.md
@@ -3,7 +3,7 @@ Trust DID Web - `did:tdw`
 
 **Specification Status:** DRAFT
 
-**Specification Version:** 0.2 (see [Changelog](#did-tdw-version-changelog))
+**Specification Version:** 0.3 (see [Changelog](#did-tdw-version-changelog))
 
 **Latest Draft:**
   [https://github.com/bcgov/trustdidweb](https://github.com/bcgov/trustdidweb)
@@ -13,6 +13,7 @@ Trust DID Web - `did:tdw`
 ~ [John Jordan, BC Gov](https://github.com/jljordan42)
 ~ [Andrew Whitehead](https://github.com/andrewwhitehead)
 ~ [Brian Richter](https://github.com/brianorwhatever)
+~ [Michel Sahli](https://github.com/bj-ms)
 
 **Participate:**
 ~ [GitHub repo](https://github.com/bcgov/trustdidweb)

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -613,7 +613,7 @@ first [[ref: DID log entry]] and is the hash of the DID's inception event.
 To generate the required [[ref: SCID]] for a `did:tdw` DID, the DID Controller
 **MUST** execute the following function:
 
- `base58(multihash(JCS(preliminary log entry with placeholders)))`
+ `base58btc(multihash(JCS(preliminary log entry with placeholders)))`
 
 Where:
 
@@ -636,8 +636,8 @@ Where:
 3. `multihash` is an implementation of the [[ref: multihash]].
    Acceptable multihash identifier are defined in [[spec:controller-document]].
    Its output is a hash prefixed with a hash function identifier and the hash size.
-4. `base58` is an implementation of the [[ref: base58]] function.
-   Its output is the Base58 encoded string of its input.
+4. `base58btc` is an implementation of the [[ref: base58btc]] function.
+   Its output is the base58 encoded string of its input.
 
 ##### Verify SCID
 
@@ -671,7 +671,7 @@ previous log entry.
 ##### Generate Entry Hash
 
 To generate the required hash for a `did:tdw` DID entry, the DID Controller
-**MUST** execute the process `base58(multihash(JCS(entry)))` given a
+**MUST** execute the process `base58btc(multihash(JCS(entry)))` given a
 preliminary log entry as the string `entry`, where:
 
 1. `JCS` is an implementation of the [[ref: JSON Canonicalization Scheme]]
@@ -680,8 +680,8 @@ preliminary log entry as the string `entry`, where:
 2. `multihash` is an implementation of the [[ref: multihash]].
    Acceptable multihash identifier are defined in [[spec:controller-document]].
    Its output is a hash prefixed with a hash function identifier and the hash size.
-3. `base58` is an implementation of the [[ref: base58]] function.
-   Its output is the Base58 encoded string of its input.
+3. `base58btc` is an implementation of the [[ref: base58btc]] function.
+   Its output is the base58 encoded string of its input.
 
 The following is an example of a preliminary log entry that is processed to
 produce an entry hash. As this is a first entry in a DID Log, the input
@@ -711,7 +711,7 @@ Resolver **MUST** execute the following process:
 3. Set the first item of the entry to the `versionId` (first item) of the
    previous log entry. If this is the first entry in the log, set the value to
    the `1-<scid>` where `<scid>` if the SCID of the DID.
-4. Calculate the hash string as `base58(multihash(JCS(entry)))`, where:
+4. Calculate the hash string as `base58btc(multihash(JCS(entry)))`, where:
    1. `entry` is the data from the previous step.
    2. `JCS` is an implementation of the [[ref: JSON Canonicalization Scheme]]
       ([[spec:rfc8785]]). Its output is a canonicalized representation of its
@@ -719,8 +719,8 @@ Resolver **MUST** execute the following process:
    3. `multihash` is an implementation of the [[ref: multihash]].
       Acceptable multihash identifier are defined in [[spec:controller-document]].
       Its output is a hash prefixed with a hash function identifier and the hash size.
-   4. `base58` as defined by the [[ref: base58]] function. Its
-      output is the Base58 encoded string of the input hash.
+   4. `base58btc` as defined by the [[ref: base58btc]] function. Its
+      output is the base58 encoded string of the input hash.
 5. Verify that the calculated value matches the extracted value from Step 1. If
    not, terminate the resolution process with an error.
 
@@ -823,13 +823,13 @@ authorization key.
 1. Generate a new key pair.
 2. Generate a [[ref: multikeys]] representation of the public key of the new key
    pair.
-3. Calculate the hash string as `base58(multihash(multikey))`, where:
+3. Calculate the hash string as `base58btc(multihash(multikey))`, where:
    1. `multikey` is the [[ref: multikey]] representation of the public key.
    2. `multihash` is an implementation of the [[ref: multihash]].
       Acceptable multihash identifier are defined in [[spec:controller-document]].
       Its output is a hash prefixed with a hash function identifier and the hash size.
-   3. `base58` as defined by the [[ref: base58]] function. Its
-      output is the Base58 encoded string of the input hash.
+   3. `base58btc` as defined by the [[ref: base58btc]] function. Its
+      output is the base58 encoded string of the input hash.
 4. Insert the calculated hash into the `nextKeyHashes` array being built up within
    the [[ref: parameters]] item.
 5. The generated key pair **SHOULD** be safely stored so that it can be used in

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -47,8 +47,6 @@ here the full ABNF of those elements from that RFC would inevitably be wrong.
 tdw-did = "did:tdw:" scid ":" domain-segment 1+( "." domain-segment ) *( ":" path-segment )
 domain-segment = ; A part of a domain name as defined in RFC3986, such as "example" and "com" in "example.com"
 path-segment= ; A part of a URL path as defined in RFC3986, such as "path", "to", "folder" in "path/to/folder"
-scid = ( base58 )
-base58 = [1-9A-Za-z]
 ```
 
 The ABNF for a `did:tdw` is almost identical to that of [[ref: did:web]], with changes only to

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -47,8 +47,8 @@ here the full ABNF of those elements from that RFC would inevitably be wrong.
 tdw-did = "did:tdw:" scid ":" domain-segment 1+( "." domain-segment ) *( ":" path-segment )
 domain-segment = ; A part of a domain name as defined in RFC3986, such as "example" and "com" in "example.com"
 path-segment= ; A part of a URL path as defined in RFC3986, such as "path", "to", "folder" in "path/to/folder"
-scid = 28+( lower-base32 )
-lower-base32 = [2-7a-z]
+scid = ( base58 )
+base58 = [1-9A-Za-z]
 ```
 
 The ABNF for a `did:tdw` is almost identical to that of [[ref: did:web]], with changes only to
@@ -620,7 +620,7 @@ first [[ref: DID log entry]] and is a portion of the hash of the DID's inception
 To generate the required [[ref: SCID]] for a `did:tdw` DID, the DID Controller
 **MUST** execute the following function:
 
- `left(base32_lower(hash(JCS(preliminary log entry with placeholders))), <length>)`
+ `base58(hash(JCS(preliminary log entry with placeholders)))`
 
 Where:
 
@@ -643,10 +643,8 @@ Where:
 3. `hash` is the hash algorithm enumerated in the `hash` item in the [[ref:
    parameters]], or if none is specified, the default hash algorithm defined in
    this specification. Its output is the hash of its input.
-4. `base32_lower` is an implementation of the [[ref: base32_lower]] function.
-   Its output is the lower case of the Base32 encoded string of its input.
-5. `left` extracts the `<length>` number of characters from the string input.
-   1. `<length>` **MUST** be at least 28 characters.
+4. `base58` is an implementation of the [[ref: base58]] function.
+   Its output is the Base58 encoded string of its input.
 
 ##### Verify SCID
 
@@ -680,7 +678,7 @@ previous log entry.
 ##### Generate Entry Hash
 
 To generate the required hash for a `did:tdw` DID entry, the DID Controller
-**MUST** execute the process `base32_lower(hash(JCS(entry)))` given a
+**MUST** execute the process `base58(hash(JCS(entry)))` given a
 preliminary log entry as the string `entry`, where:
 
 1. `JCS` is an implementation of the [[ref: JSON Canonicalization Scheme]]
@@ -689,8 +687,8 @@ preliminary log entry as the string `entry`, where:
 2. `hash` is the hash algorithm enumerated in the `hash` item in the [[ref:
    parameters]], or if none is specified, the default hash algorithm defined in
    this specification. Its output is the hash of its input.
-3. `base32_lower` is an implementation of the [[ref: base32_lower]] function.
-   Its output is the lower case of the Base32 encoded string of its input.
+3. `base58` is an implementation of the [[ref: base58]] function.
+   Its output is the Base58 encoded string of its input.
 
 The following is an example of a preliminary log entry that is processed to
 produce an entry hash. As this is a first entry in a DID Log, the input
@@ -720,7 +718,7 @@ Resolver **MUST** execute the following process:
 3. Set the first item of the entry to the `versionId` (first item) of the
    previous log entry. If this is the first entry in the log, set the value to
    the `1-<scid>` where `<scid>` if the SCID of the DID.
-4. Calculate the hash string as `base32_lower(hash(JCS(entry)))`, where:
+4. Calculate the hash string as `base58(hash(JCS(entry)))`, where:
    1. `entry` is the data from the previous step.
    2. `JCS` is an implementation of the [[ref: JSON Canonicalization Scheme]]
       ([[spec:rfc8785]]). Its output is a canonicalized representation of its
@@ -728,8 +726,8 @@ Resolver **MUST** execute the following process:
    3. `hash` is the hash algorithm enumerated in the `hash` item in the [[ref:
       parameters]], or if none is specified, the default hash algorithm defined in
       this specification. Its output is the hash of its input.
-   4. `base32_lower` as defined by the [[ref: base32_lower]] function. Its
-      output is the lower case of the Base32 encoded string of the input hash.
+   4. `base58` as defined by the [[ref: base58]] function. Its
+      output is the Base58 encoded string of the input hash.
 5. Verify that the calculated value matches the extracted value from Step 1. If
    not, terminate the resolution process with an error.
 
@@ -832,14 +830,14 @@ authorization key.
 1. Generate a new key pair.
 2. Generate a [[ref: multikeys]] representation of the public key of the new key
    pair.
-3. Calculate the hash string as `base32_lower(hash(multikey))`, where:
+3. Calculate the hash string as `base58(hash(multikey))`, where:
    1. `multikey` is the [[ref: multikey]] representation of the public key.
    2. ``hash` is the most recent hash algorithm enumerated in the `hash` item in
       the [[ref: parameters]], or if none is specified, the default hash
       algorithm defined in this specification. Its output is the hash of its
       input.
-   3. `base32_lower` as defined by the [[ref: base32_lower]] function. Its
-      output is the lower case of the Base32 encoded string of the input hash.
+   3. `base58` as defined by the [[ref: base58]] function. Its
+      output is the Base58 encoded string of the input hash.
 4. Insert the calculated hash into the `nextKeyHashes` array being built up within
    the [[ref: parameters]] item.
 5. The generated key pair **SHOULD** be safely stored so that it can be used in

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -506,7 +506,7 @@ An example of the JSON prettified parameters item in the first DID Log entry for
     "nextKeyHashes": [
       "enkkrohe5ccxyc7zghic6qux5inyzthg2tqka4b57kvtorysc3aa"
     ],
-    "method": "did:tdw:0.2",
+    "method": "did:tdw:0.3",
     "scid": "{SCID}"
 }
 ```
@@ -526,7 +526,7 @@ items are defined below.
     the processing rules for that and later entries have been changed to a
     different specification version.
   - Acceptable values for this specification are:
-    - `did:tdw:0.2`: Requires that the rules defined in this specification be used
+    - `did:tdw:0.3`: Requires that the rules defined in this specification be used
       in processing the log.
 - `scid`: The value of the [[ref: SCID]] for this DID.
   - This item **MUST** appear in the first [[ref: DID log entry]].

--- a/spec/specification.md
+++ b/spec/specification.md
@@ -500,7 +500,6 @@ An example of the JSON prettified parameters item in the first DID Log entry for
 
 ``` json
 {
-    "hash": "sha-256",
     "prerotation": true,
     "portable": false,
     "updateKeys": [
@@ -552,10 +551,6 @@ items are defined below.
   - Once the value has been set to `false`, it cannot be set back to `true`.
   - See the section of this specification on [DID Portability](#did-portability)
     for more details about renaming a `did:tdw` DID.
-- `hash`: The hashing algorithm to use when executing hashes.
-  - By default, the value is initialized to `sha-256`.
-  - Acceptable values:
-    - `sha-256`: Use the `SHA-256` algorithm from [[spec:rfc4634]].
 - `cryptosuite`: The Data Integrity cryptosuite to use when generating and
   verifying the authentication proofs on the [[ref: DID log entries]].
   - By default, the value is initialized to `eddsa-jcs-2022`
@@ -613,14 +608,14 @@ items are defined below.
 #### SCID Generation and Verification
 
 The [[ref: Self-certifying identifier]] or `SCID` is a required parameter in the
-first [[ref: DID log entry]] and is a portion of the hash of the DID's inception event.
+first [[ref: DID log entry]] and is the hash of the DID's inception event.
 
 ##### Generate SCID
 
 To generate the required [[ref: SCID]] for a `did:tdw` DID, the DID Controller
 **MUST** execute the following function:
 
- `base58(hash(JCS(preliminary log entry with placeholders)))`
+ `base58(multihash(JCS(preliminary log entry with placeholders)))`
 
 Where:
 
@@ -640,9 +635,9 @@ Where:
 2. `JCS` is an implementation of the [[ref: JSON Canonicalization Scheme]]
    [[spec:rfc8785]]. It outputs a canonicalized representation of its JSON
    input.
-3. `hash` is the hash algorithm enumerated in the `hash` item in the [[ref:
-   parameters]], or if none is specified, the default hash algorithm defined in
-   this specification. Its output is the hash of its input.
+3. `multihash` is an implementation of the [[ref: multihash]].
+   Acceptable multihash identifier are defined in [[spec:controller-document]].
+   Its output is a hash prefixed with a hash function identifier and the hash size.
 4. `base58` is an implementation of the [[ref: base58]] function.
    Its output is the Base58 encoded string of its input.
 
@@ -678,15 +673,15 @@ previous log entry.
 ##### Generate Entry Hash
 
 To generate the required hash for a `did:tdw` DID entry, the DID Controller
-**MUST** execute the process `base58(hash(JCS(entry)))` given a
+**MUST** execute the process `base58(multihash(JCS(entry)))` given a
 preliminary log entry as the string `entry`, where:
 
 1. `JCS` is an implementation of the [[ref: JSON Canonicalization Scheme]]
    ([[spec:rfc8785]]). Its output is a canonicalized representation of its
    input.
-2. `hash` is the hash algorithm enumerated in the `hash` item in the [[ref:
-   parameters]], or if none is specified, the default hash algorithm defined in
-   this specification. Its output is the hash of its input.
+2. `multihash` is an implementation of the [[ref: multihash]].
+   Acceptable multihash identifier are defined in [[spec:controller-document]].
+   Its output is a hash prefixed with a hash function identifier and the hash size.
 3. `base58` is an implementation of the [[ref: base58]] function.
    Its output is the Base58 encoded string of its input.
 
@@ -718,14 +713,14 @@ Resolver **MUST** execute the following process:
 3. Set the first item of the entry to the `versionId` (first item) of the
    previous log entry. If this is the first entry in the log, set the value to
    the `1-<scid>` where `<scid>` if the SCID of the DID.
-4. Calculate the hash string as `base58(hash(JCS(entry)))`, where:
+4. Calculate the hash string as `base58(multihash(JCS(entry)))`, where:
    1. `entry` is the data from the previous step.
    2. `JCS` is an implementation of the [[ref: JSON Canonicalization Scheme]]
       ([[spec:rfc8785]]). Its output is a canonicalized representation of its
       input.
-   3. `hash` is the hash algorithm enumerated in the `hash` item in the [[ref:
-      parameters]], or if none is specified, the default hash algorithm defined in
-      this specification. Its output is the hash of its input.
+   3. `multihash` is an implementation of the [[ref: multihash]].
+      Acceptable multihash identifier are defined in [[spec:controller-document]].
+      Its output is a hash prefixed with a hash function identifier and the hash size.
    4. `base58` as defined by the [[ref: base58]] function. Its
       output is the Base58 encoded string of the input hash.
 5. Verify that the calculated value matches the extracted value from Step 1. If
@@ -830,12 +825,11 @@ authorization key.
 1. Generate a new key pair.
 2. Generate a [[ref: multikeys]] representation of the public key of the new key
    pair.
-3. Calculate the hash string as `base58(hash(multikey))`, where:
+3. Calculate the hash string as `base58(multihash(multikey))`, where:
    1. `multikey` is the [[ref: multikey]] representation of the public key.
-   2. ``hash` is the most recent hash algorithm enumerated in the `hash` item in
-      the [[ref: parameters]], or if none is specified, the default hash
-      algorithm defined in this specification. Its output is the hash of its
-      input.
+   2. `multihash` is an implementation of the [[ref: multihash]].
+      Acceptable multihash identifier are defined in [[spec:controller-document]].
+      Its output is a hash prefixed with a hash function identifier and the hash size.
    3. `base58` as defined by the [[ref: base58]] function. Its
       output is the Base58 encoded string of the input hash.
 4. Insert the calculated hash into the `nextKeyHashes` array being built up within

--- a/spec/version.md
+++ b/spec/version.md
@@ -5,6 +5,7 @@ The following lists the substantive changes in each version of the specification
 - Version 0.3
   - Change base32 encoding with base58, as it offers a better expansion rate.
   - Remove the step to extract part of the base58 result during the generation of the [[ref: SCID]].
+  - Use multihash in the [[ref: SCID]] to differentiate the different hash function outputs.
 - Version 0.2
   - Changes the location of the [[ref: SCID]] in the DID to always be the first
     component after the DID Method prefix -- `did:tdw:<scid>:...`.

--- a/spec/version.md
+++ b/spec/version.md
@@ -2,6 +2,9 @@
 
 The following lists the substantive changes in each version of the specification.
 
+- Version 0.3
+  - Change base32 encoding with base58, as it offers a better expansion rate.
+  - Remove the step to extract part of the base58 result during the generation of the [[ref: SCID]].
 - Version 0.2
   - Changes the location of the [[ref: SCID]] in the DID to always be the first
     component after the DID Method prefix -- `did:tdw:<scid>:...`.


### PR DESCRIPTION
As part of the discussion and security concerns in https://github.com/bcgov/trustdidweb/issues/75, I propose to change Base32 to Base 58 and remove the shortening of the SCID during it's generation.

I also changed the version, changelog  and added myself as an author (feel free to comment on a possible rollback on that part).